### PR TITLE
Replace CI_GITHUB_TOKEN with GITHUB_TOKEN in the docs rebuild pipeline

### DIFF
--- a/.github/workflows/docs-rebuild.yml
+++ b/.github/workflows/docs-rebuild.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout Docs Repo
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Rebuild Documentation
         run: |


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/docs-next/129)
<!-- Reviewable:end -->
